### PR TITLE
Bump version to 3.13.0

### DIFF
--- a/src/instana/version.py
+++ b/src/instana/version.py
@@ -3,4 +3,4 @@
 
 # Module version file.  Used by setup.py and snapshot reporting.
 
-VERSION = "3.12.0"
+VERSION = "3.13.0"


### PR DESCRIPTION
# Summary

Version bump from 3.12.0 to 3.13.0 for the next release of the Instana Python package.

# Files Changed

📄 `src/instana/version.py`

Updates the package version constant from "3.12.0" to "3.13.0". This version is used by setup.py for package distribution and by snapshot reporting functionality.